### PR TITLE
Update ConfigAPI

### DIFF
--- a/src/main/java/net/okocraft/scoreboard/config/BoardLoader.java
+++ b/src/main/java/net/okocraft/scoreboard/config/BoardLoader.java
@@ -1,13 +1,12 @@
 package net.okocraft.scoreboard.config;
 
-import com.github.siroshun09.configapi.bukkit.BukkitConfig;
 import com.github.siroshun09.configapi.bukkit.BukkitYaml;
+import com.github.siroshun09.configapi.bukkit.BukkitYamlFactory;
 import net.okocraft.scoreboard.ScoreboardPlugin;
 import net.okocraft.scoreboard.board.Board;
 import net.okocraft.scoreboard.board.Line;
 import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.io.IOException;
@@ -16,7 +15,6 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,20 +27,13 @@ public final class BoardLoader {
     private static final String PATH_LIST_SUFFIX = ".list";
     private static final String PATH_INTERVAL_SUFFIX = ".interval";
 
-
     private BoardLoader() {
         throw new UnsupportedOperationException();
     }
 
     @NotNull
     public static Board loadDefaultBoard(@NotNull ScoreboardPlugin plugin) throws IllegalStateException {
-        Board board = load(new BukkitConfig(plugin, DEFAULT_BOARD_FILE_NAME, true));
-
-        if (board == null) {
-            throw new IllegalStateException("Could not load default board (" + DEFAULT_BOARD_FILE_NAME + ")");
-        } else {
-            return board;
-        }
+        return getBoard(BukkitYamlFactory.loadUnsafe(plugin, DEFAULT_BOARD_FILE_NAME));
     }
 
     @NotNull
@@ -56,9 +47,8 @@ public final class BoardLoader {
                         .filter(Files::isRegularFile)
                         .filter(Files::isReadable)
                         .filter(p -> !p.toString().endsWith(DEFAULT_BOARD_FILE_NAME))
-                        .map(BukkitYaml::new)
-                        .map(BoardLoader::load)
-                        .filter(Objects::nonNull)
+                        .map(BukkitYamlFactory::loadUnsafe)
+                        .map(BoardLoader::getBoard)
                         .collect(Collectors.toUnmodifiableSet());
             } catch (IOException e) {
                 throw new IllegalStateException(e);
@@ -73,12 +63,7 @@ public final class BoardLoader {
         }
     }
 
-    @Nullable
-    private static Board load(@NotNull BukkitYaml yaml) {
-        if (!yaml.load()) {
-            return null;
-        }
-
+    private static @NotNull Board getBoard(@NotNull BukkitYaml yaml) {
         List<String> titleList = yaml.getStringList(PATH_TITLE + PATH_LIST_SUFFIX);
         Line title;
 

--- a/src/main/java/net/okocraft/scoreboard/config/Configuration.java
+++ b/src/main/java/net/okocraft/scoreboard/config/Configuration.java
@@ -1,6 +1,7 @@
 package net.okocraft.scoreboard.config;
 
-import com.github.siroshun09.configapi.bukkit.BukkitConfig;
+import com.github.siroshun09.configapi.bukkit.BukkitYamlFactory;
+import com.github.siroshun09.configapi.common.yaml.Yaml;
 import net.okocraft.scoreboard.ScoreboardPlugin;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,10 +10,10 @@ public class Configuration {
     private static final int DEFAULT_BOARD_LIMIT = 32;
     private static final int DEFAULT_THREADS = 5;
 
-    private final BukkitConfig config;
+    private final Yaml config;
 
     public Configuration(@NotNull ScoreboardPlugin plugin) {
-        config = new BukkitConfig(plugin, "config.yml", true);
+        config = BukkitYamlFactory.loadUnsafe(plugin, "config.yml");
     }
 
     public boolean isUsingProtocolLib() {
@@ -20,10 +21,10 @@ public class Configuration {
     }
 
     public int getLengthLimit() {
-        return Math.max(config.getInt("board.limit", DEFAULT_BOARD_LIMIT), 1);
+        return Math.max(config.getInteger("board.limit", DEFAULT_BOARD_LIMIT), 1);
     }
 
     public int getThreads() {
-        return Math.max(config.getInt("board.threads", DEFAULT_THREADS), 1);
+        return Math.max(config.getInteger("board.threads", DEFAULT_THREADS), 1);
     }
 }


### PR DESCRIPTION
ConfigAPI 2.x.x では `BukkitConfig` が削除され `BukkitYamlFactory` から `Yaml` インスタンスを取得するようになっている。

また、 `Yaml#getInt` から `Yaml#getInteger` など些細な変更もあるので、それらを修正する。